### PR TITLE
H2-Console의 모든 주소에 인증없이 접근 가능하도록 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,10 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.3.1'
+
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
+	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/fastcampus/board/__core/security/SecurityConfig.java
+++ b/src/main/java/com/fastcampus/board/__core/security/SecurityConfig.java
@@ -1,0 +1,26 @@
+package com.fastcampus.board.__core.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf().disable()
+
+                .authorizeRequests()
+                .antMatchers("/h2-console/**")
+                .permitAll()
+                .anyRequest()
+                .authenticated()
+
+                .and().headers().frameOptions().sameOrigin();
+
+        return http.build();
+    }
+}


### PR DESCRIPTION
H2-Console의 모든 주소에 인증없이 접근 가능하도록 설정
- `/h2-console/**` 요청을 인증없이 허용하도록 변경
- `csrf `비활성화
- `HTTP`응답 헤더에 프레임 옵션을 `SAMEORIGIN`으로 설정

fix: #2 